### PR TITLE
readme: fix link to npm page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Loadsmart's React Native Components
 
 [![Build Status](https://circleci.com/gh/loadsmart/blocks.svg?style=shield)](https://circleci.com/gh/loadsmart/blocks/tree/master)
 [![codecov](https://codecov.io/gh/loadsmart/blocks/branch/master/graph/badge.svg)](https://codecov.io/gh/loadsmart/blocks)
-![npm (scoped)](https://img.shields.io/npm/v/@loadsmart/blocks.svg)
+[![npm (scoped)](https://img.shields.io/npm/v/@loadsmart/blocks.svg)](https://www.npmjs.com/package/@loadsmart/blocks)
 
 ## Installation
 


### PR DESCRIPTION
Badge link was pointing to a wrong page. Now it points to blocks' main page on NPM.