### PR TITLE
Fix focus issue on PinCode component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix PinCodeInputText focus issue (@barbosa)
 
 ## [1.1.0] - 2019-09-12
 ### Added

--- a/src/components/TextInputs/PinCodeTextInput.tsx
+++ b/src/components/TextInputs/PinCodeTextInput.tsx
@@ -61,12 +61,17 @@ export default class PinCodeTextInput extends Component<Props, State> {
   }
 
   public updatePinCodeInputFocus = (index: number, inputRefs: NumberInput[], text: string) => {
-    if (text.length === 0 && index > 0) {
-      inputRefs[index - 1].focus()
+    const isDeleting = text.length === 0
+    if (isDeleting) {
       inputRefs[index].blur()
+      if (index > 0) {
+        inputRefs[index - 1].focus()
+      }
     } else {
       inputRefs[index].blur()
-      if (index !== inputRefs.length - 1) inputRefs[index + 1].focus()
+      if (index !== inputRefs.length - 1) {
+        inputRefs[index + 1].focus()
+      }
     }
   }
 }

--- a/src/components/TextInputs/PinCodeTextInput.tsx
+++ b/src/components/TextInputs/PinCodeTextInput.tsx
@@ -63,8 +63,8 @@ export default class PinCodeTextInput extends Component<Props, State> {
   public updatePinCodeInputFocus = (index: number, inputRefs: NumberInput[], text: string) => {
     const isDeleting = text.length === 0
     if (isDeleting) {
-      inputRefs[index].blur()
       if (index > 0) {
+        inputRefs[index].blur()
         inputRefs[index - 1].focus()
       }
     } else {

--- a/src/components/TextInputs/__tests__/PinCodeTextInput.test.tsx
+++ b/src/components/TextInputs/__tests__/PinCodeTextInput.test.tsx
@@ -98,7 +98,7 @@ describe('PinCodeTextInput', () => {
       expect(inputRefs[1].blur).toHaveBeenCalled()
     })
 
-    it('blurs the current number input if it is the first and is deleting', () => {
+    it('neither blurs not focus the current number input if it is the first and is deleting', () => {
       const testRenderer = renderer.create(<PinCodeTextInput onChangeInput={onChangeInput} />)
       const inputRefs = [
         {
@@ -111,7 +111,11 @@ describe('PinCodeTextInput', () => {
         },
       ]
       testRenderer.root.instance.updatePinCodeInputFocus(0, inputRefs, '')
-      expect(inputRefs[0].blur).toHaveBeenCalled()
+
+      expect(inputRefs[0].blur).not.toHaveBeenCalled()
+      expect(inputRefs[0].focus).not.toHaveBeenCalled()
+
+      expect(inputRefs[1].blur).not.toHaveBeenCalled()
       expect(inputRefs[1].focus).not.toHaveBeenCalled()
     })
 

--- a/src/components/TextInputs/__tests__/PinCodeTextInput.test.tsx
+++ b/src/components/TextInputs/__tests__/PinCodeTextInput.test.tsx
@@ -98,6 +98,23 @@ describe('PinCodeTextInput', () => {
       expect(inputRefs[1].blur).toHaveBeenCalled()
     })
 
+    it('blurs the current number input if it is the first and is deleting', () => {
+      const testRenderer = renderer.create(<PinCodeTextInput onChangeInput={onChangeInput} />)
+      const inputRefs = [
+        {
+          blur: jest.fn(),
+          focus: jest.fn(),
+        },
+        {
+          blur: jest.fn(),
+          focus: jest.fn(),
+        },
+      ]
+      testRenderer.root.instance.updatePinCodeInputFocus(0, inputRefs, '')
+      expect(inputRefs[0].blur).toHaveBeenCalled()
+      expect(inputRefs[1].focus).not.toHaveBeenCalled()
+    })
+
     it('blurs the current number input and focus the previous one if deleting', () => {
       const testRenderer = renderer.create(<PinCodeTextInput onChangeInput={onChangeInput} />)
       const inputRefs = [


### PR DESCRIPTION
Pressing `backspace` when first digit was in focus would move cursor to the second digit. Now it just won't do anything.