### PR TITLE
refactor: pass some props like testID down to components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
-  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '.d.ts$'],
   cacheDirectory: '.jest/cache',
   coverageDirectory: './coverage/',
   collectCoverage: true,

--- a/src/components/Banners/AlertBanner.tsx
+++ b/src/components/Banners/AlertBanner.tsx
@@ -5,14 +5,15 @@ import { BannerDisplayStyle, BannerProps } from './BannerProps'
 
 export default class AlertBanner extends PureComponent<BannerProps> {
   public render() {
+    const { message, onPress, testID } = this.props
     const styles = stylesFromProps(this.props)
     return (
-      <TouchableWithoutFeedback onPress={this.props.onPress}>
+      <TouchableWithoutFeedback {...{ onPress, testID }}>
         <View style={[styles.wrapper, this.props.style]}>
           <Image source={Images.Warning} />
-          {this.props.message && (
+          {message && (
             <Text style={styles.text} numberOfLines={2}>
-              {this.props.message}
+              {message}
             </Text>
           )}
         </View>

--- a/src/components/Buttons/PrimaryButton.tsx
+++ b/src/components/Buttons/PrimaryButton.tsx
@@ -10,17 +10,16 @@ export default class PrimaryButton extends PureComponent<ButtonProps> {
   }
 
   public render() {
+    const { displayState, testID } = this.props
     return (
       <ThemeContext.Consumer>
         {theme => {
           const styles = themedStyles(theme, this.props.style)
           return (
-            <TouchableOpacity onPress={this.onPress.bind(this)}>
+            <TouchableOpacity onPress={this.onPress.bind(this)} {...{ testID }}>
               <View style={[styles.wrapper, this.props.style]}>
-                {this.props.displayState !== ButtonDisplayState.Loading &&
-                  this.renderNormalState(styles)}
-                {this.props.displayState === ButtonDisplayState.Loading &&
-                  this.renderLoadingState(styles)}
+                {displayState !== ButtonDisplayState.Loading && this.renderNormalState(styles)}
+                {displayState === ButtonDisplayState.Loading && this.renderLoadingState(styles)}
               </View>
             </TouchableOpacity>
           )

--- a/src/components/Buttons/SecondaryButton.tsx
+++ b/src/components/Buttons/SecondaryButton.tsx
@@ -9,14 +9,17 @@ export default class SecondaryButton extends PureComponent<ButtonProps> {
   }
 
   public render() {
+    const { displayState, testID } = this.props
     const styles = stylesFromProps(this.props)
+
     return (
       <TouchableOpacity
         onPress={this.onPress.bind(this)}
         style={[styles.wrapper, this.props.style]}
+        {...{ testID }}
       >
-        {this.props.displayState !== ButtonDisplayState.Loading && this.renderNormalState()}
-        {this.props.displayState === ButtonDisplayState.Loading && this.renderLoadingState()}
+        {displayState !== ButtonDisplayState.Loading && this.renderNormalState()}
+        {displayState === ButtonDisplayState.Loading && this.renderLoadingState()}
       </TouchableOpacity>
     )
   }

--- a/src/components/Buttons/TertiaryButton.tsx
+++ b/src/components/Buttons/TertiaryButton.tsx
@@ -11,11 +11,13 @@ interface Props extends ViewProps {
 
 export default class TertiaryButton extends PureComponent<Props> {
   public render() {
+    const { title, onPress, testID } = this.props
     const styles = stylesFromProps(this.props)
+
     return (
-      <TouchableOpacity onPress={this.props.onPress}>
+      <TouchableOpacity {...{ onPress, testID }}>
         <>
-          <Text style={[styles.title, this.props.style]}>{this.props.title}</Text>
+          <Text style={[styles.title, this.props.style]}>{title}</Text>
         </>
       </TouchableOpacity>
     )

--- a/src/components/Cells/RadioSelectCell.tsx
+++ b/src/components/Cells/RadioSelectCell.tsx
@@ -10,12 +10,12 @@ interface Props extends ViewProps {
 
 export default class RadioSelectCell extends Component<Props> {
   public render() {
-    const { selected, title } = this.props
+    const { selected, title, testID } = this.props
     const extraTitleStyle = {
       fontFamily: selected ? Fonts.SharpSansBold : Fonts.SharpSansMedium,
     }
     return (
-      <View style={[styles.container, this.props.style]}>
+      <View style={[styles.container, this.props.style]} {...{ testID }}>
         <Radio selected={selected === true} style={styles.radio} />
         <Text style={[styles.title, extraTitleStyle]}>{title}</Text>
       </View>

--- a/src/components/Cells/TitleValueCell.tsx
+++ b/src/components/Cells/TitleValueCell.tsx
@@ -21,9 +21,9 @@ interface Props extends ComponentProps<any> {
 
 export default class TitleValueCell extends PureComponent<Props> {
   public render() {
-    const { icon, title, value, hasChevron, style, valueStyle } = this.props
+    const { icon, title, value, hasChevron, style, valueStyle, testID } = this.props
     return (
-      <View style={[styles.container, style]}>
+      <View style={[styles.container, style]} {...{ testID }}>
         <View style={styles.titleWrapper}>
           {icon && <Image source={icon} style={styles.icon} />}
           <Text style={styles.title}>{title}</Text>

--- a/src/components/Dialogs/Dialog.tsx
+++ b/src/components/Dialogs/Dialog.tsx
@@ -25,19 +25,16 @@ export interface DialogProps extends DismissibleModalProps {
 
 export class Dialog extends PureComponent<DialogProps> {
   public render() {
+    const { image, imageStyle, title, titleStyle, message, inputField, buttons } = this.props
     const buttonsMarginStyle = { marginTop: this.props.inputField ? 8 : 22 }
 
     return (
       <DialogBox {...this.props} dialogStyle={styles.box}>
-        {this.props.image && <Image source={this.props.image} style={this.props.imageStyle} />}
-        {this.props.title && (
-          <Text style={[styles.title, this.props.titleStyle]}>{this.props.title}</Text>
-        )}
-        {this.props.message && <Text style={styles.message}>{this.props.message}</Text>}
-        {this.props.inputField && <View style={styles.inputField}>{this.props.inputField}</View>}
-        {this.props.buttons && (
-          <View style={[styles.buttons, buttonsMarginStyle]}>{this.props.buttons}</View>
-        )}
+        {image && <Image source={image} style={imageStyle} />}
+        {title && <Text style={[styles.title, titleStyle]}>{title}</Text>}
+        {message && <Text style={styles.message}>{message}</Text>}
+        {inputField && <View style={styles.inputField}>{inputField}</View>}
+        {buttons && <View style={[styles.buttons, buttonsMarginStyle]}>{buttons}</View>}
       </DialogBox>
     )
   }

--- a/src/components/Dialogs/DialogBox.tsx
+++ b/src/components/Dialogs/DialogBox.tsx
@@ -8,13 +8,14 @@ interface Props extends DismissibleModalProps {
 
 export default class DialogBox extends PureComponent<Props> {
   public render() {
+    const { dialogStyle, children, onPressOutside } = this.props
     return (
       <Modal {...this.props} animationType={'fade'} transparent={true}>
-        <TouchableWithoutFeedback onPress={this.props.onPressOutside}>
+        <TouchableWithoutFeedback onPress={onPressOutside}>
           <View style={styles.modal}>
-            {/* this is needed to avoid outside view 'stealing' the click from the dialog box */}
+            {/* this is needed to avoid outside view 'stealing' the tap from the dialog box */}
             <TouchableWithoutFeedback>
-              <View style={[styles.box, this.props.dialogStyle]}>{this.props.children}</View>
+              <View style={[styles.box, dialogStyle]}>{children}</View>
             </TouchableWithoutFeedback>
           </View>
         </TouchableWithoutFeedback>

--- a/src/components/Icons/IconChevron.tsx
+++ b/src/components/Icons/IconChevron.tsx
@@ -8,9 +8,10 @@ interface Props extends ViewProps {
 
 export default class IconChevron extends PureComponent<Props> {
   public render() {
+    const { style, testID } = this.props
     const tintColor = this.props.tintColor ? this.props.tintColor : Colors.LightGray
     return (
-      <View style={this.props.style}>
+      <View {...{ style, testID }}>
         <Image source={Images.Chevron} style={{ tintColor }} />
       </View>
     )

--- a/src/components/Radios/Radio.tsx
+++ b/src/components/Radios/Radio.tsx
@@ -9,13 +9,17 @@ interface Props extends ViewProps {
 
 export default class Radio extends PureComponent<Props> {
   public render() {
+    const { selected, testID } = this.props
     return (
       <ThemeContext.Consumer>
         {theme => {
-          const isSelected = this.props.selected === true
+          const isSelected = selected === true
           const color = isSelected ? theme.primaryColor : Colors.Tuna
           return (
-            <View style={[styles.outerCircle, this.props.style, { borderColor: color }]}>
+            <View
+              style={[styles.outerCircle, this.props.style, { borderColor: color }]}
+              {...{ testID }}
+            >
               {isSelected && <View style={[styles.innerCircle, { backgroundColor: color }]} />}
             </View>
           )

--- a/src/components/Selectors/RadioSelector.tsx
+++ b/src/components/Selectors/RadioSelector.tsx
@@ -1,4 +1,4 @@
-import React, { Component, PureComponent } from 'react'
+import React, { Component } from 'react'
 import { FlatList, TouchableWithoutFeedback, View, ViewProps } from 'react-native'
 import { Colors } from '../../res'
 import { RadioSelectCell } from '../Cells'
@@ -20,15 +20,17 @@ export default class RadioSelector extends Component<Props, State> {
   }
 
   public render() {
+    const { items, testID } = this.props
     return (
       <FlatList
-        data={this.props.items}
+        data={items}
         keyExtractor={(_, index) => `${index}`}
         extraData={this.state}
         renderItem={this.renderItem.bind(this)}
         showsVerticalScrollIndicator={false}
         style={this.props.style}
         ItemSeparatorComponent={this.renderSeparator.bind(this)}
+        {...{ testID }}
       />
     )
   }

--- a/src/components/TextInputs/NumberInput.tsx
+++ b/src/components/TextInputs/NumberInput.tsx
@@ -33,6 +33,7 @@ export default class NumberInput extends PureComponent<Props, State> {
   }
 
   public render() {
+    const { digit, testID } = this.props
     return (
       <ThemeContext.Consumer>
         {theme => {
@@ -50,9 +51,10 @@ export default class NumberInput extends PureComponent<Props, State> {
               onBlur={this.onBlur}
               onFocus={this.onFocus}
               blurOnSubmit={false}
-              value={this.props.digit}
+              value={digit}
               onKeyPress={this.onKeyPress}
               caretHidden={true}
+              {...{ testID }}
             />
           )
         }}

--- a/src/components/TextInputs/PhoneTextInput.tsx
+++ b/src/components/TextInputs/PhoneTextInput.tsx
@@ -20,12 +20,14 @@ export default class PhoneTextInput extends Component<Props, State> {
   }
 
   public render() {
+    const { placeholder, testID } = this.props
     return (
       <TextInput
-        placeholder={this.props.placeholder ? this.props.placeholder : ''}
+        placeholder={placeholder ? placeholder : ''}
         onChangeText={phone => this.applyChanges(phone)}
         keyboardType={'phone-pad'}
         value={this.state.phoneNumber}
+        {...{ testID }}
       />
     )
   }


### PR DESCRIPTION
I'm configuring [wix/detox](https://github.com/wix/detox) which is an e2e testing tool for mobile apps and some components need a `testID` set so we can use `matchers` to properly find them.

closes #47 